### PR TITLE
Minor Fix to Title Bar Text Cursor Positioning

### DIFF
--- a/demos/hello-world/src/ui/components/title_bar.rs
+++ b/demos/hello-world/src/ui/components/title_bar.rs
@@ -4,8 +4,7 @@ widget_component! {
     pub title_bar(id, key, state) [use_button_notified_state, use_text_input_notified_state] {
         let ButtonProps { selected, trigger, .. } = state.read_cloned_or_default();
         let TextInputProps { text, cursor_position, focused, .. } = state.read_cloned_or_default();
-        let text = text.trim();
-        let text = if text.is_empty() {
+        let text = if text.trim().is_empty() {
             "> Focus here and start typing...".to_owned()
         } else if focused {
             if cursor_position < text.len() {


### PR DESCRIPTION
This just fixes a minor annoyance where the cursor doesn't indicate the spaces that you type into the box because of the `trim()`.