### PR TITLE
Use Valid Function Syntax for widget_component!

### DIFF
--- a/demos/hello-world/src/ui/components/app.rs
+++ b/demos/hello-world/src/ui/components/app.rs
@@ -1,25 +1,26 @@
 use raui_core::prelude::*;
 
-widget_component! {
-    pub app(key, named_slots) {
-        unpack_named_slots!(named_slots => { title, content });
-
-        title.remap_props(|props| props.with(FlexBoxItemLayout {
-            grow: 0.0,
-            shrink: 0.0,
-            ..Default::default()
-        }));
+widget_component!(
+    pub fn app(key: Key, (title, content): NamedSlots) {
+        dbg!(&title);
+        title.remap_props(|props| {
+            props.with(FlexBoxItemLayout {
+                grow: 0.0,
+                shrink: 0.0,
+                ..Default::default()
+            })
+        });
         let props = Props::new(VerticalBoxProps {
             separation: 16.0,
             ..Default::default()
         })
         .with(NavJumpLooped);
 
-        widget!{
+        widget! {
             (#{key} nav_vertical_box: {props} [
                 {title}
                 {content}
             ])
         }
     }
-}
+);

--- a/demos/hello-world/src/ui/components/color_rect.rs
+++ b/demos/hello-world/src/ui/components/color_rect.rs
@@ -8,8 +8,8 @@ pub struct ColorRectProps {
 }
 implement_props_data!(ColorRectProps);
 
-widget_component! {
-    pub color_rect(key, props) {
+widget_component!(
+    pub fn color_rect(key: Key, props: Props) {
         let color = props.read_cloned_or_default::<ColorRectProps>().color;
         let props = props.clone().with(ImageBoxProps {
             material: ImageBoxMaterial::Color(ImageBoxColor {
@@ -23,4 +23,4 @@ widget_component! {
             (#{key} image_box: {props})
         }
     }
-}
+);

--- a/demos/hello-world/src/ui/components/content.rs
+++ b/demos/hello-world/src/ui/components/content.rs
@@ -4,8 +4,8 @@ use crate::ui::components::{
 };
 use raui_core::prelude::*;
 
-widget_component! {
-    pub content(key, props, shared_props) {
+widget_component!(
+    pub fn content(key: Key, props: Props, shared_props: SharedProps) {
         let props0 = Props::new(ImageButtonProps {
             image: "cat".to_owned(),
             horizontal_alignment: 1.0,
@@ -27,7 +27,12 @@ widget_component! {
         });
 
         let props1 = Props::new(ColorRectProps {
-            color: Color { r: 1.0, g: 0.0, b: 0.0, a: 0.5 },
+            color: Color {
+                r: 1.0,
+                g: 0.0,
+                b: 0.0,
+                a: 0.5,
+            },
         })
         .with(GridBoxItemLayout {
             space_occupancy: IntRect {
@@ -79,4 +84,4 @@ widget_component! {
             ])
         }
     }
-}
+);

--- a/demos/hello-world/src/ui/components/image_button.rs
+++ b/demos/hello-world/src/ui/components/image_button.rs
@@ -10,8 +10,9 @@ pub struct ImageButtonProps {
 }
 implement_props_data!(ImageButtonProps);
 
-widget_component! {
-    pub image_button(id, key, props, state) [use_button_notified_state] {
+widget_component!(
+    #[pre(use_button_notified_state)]
+    pub fn image_button(id: Id, key: Key, props: Props, state: State) {
         let ImageButtonProps {
             image,
             horizontal_alignment,
@@ -23,30 +24,36 @@ widget_component! {
             ..
         } = state.read_cloned_or_default();
         let scale = if trigger || context {
-            Vec2 {
-                x: 1.1,
-                y: 1.1,
-            }
+            Vec2 { x: 1.1, y: 1.1 }
         } else if selected {
-            Vec2 {
-                x: 1.05,
-                y: 1.05,
-            }
+            Vec2 { x: 1.05, y: 1.05 }
         } else {
-            Vec2 {
-                x: 1.0,
-                y: 1.0,
-            }
+            Vec2 { x: 1.0, y: 1.0 }
         };
         let image_props = ImageBoxProps {
             material: ImageBoxMaterial::Image(ImageBoxImage {
                 id: image,
                 tint: if trigger {
-                    Color { r: 0.0, g: 1.0, b: 0.0, a: 1.0 }
+                    Color {
+                        r: 0.0,
+                        g: 1.0,
+                        b: 0.0,
+                        a: 1.0,
+                    }
                 } else if context {
-                    Color { r: 1.0, g: 0.0, b: 0.0, a: 1.0 }
+                    Color {
+                        r: 1.0,
+                        g: 0.0,
+                        b: 0.0,
+                        a: 1.0,
+                    }
                 } else if selected {
-                    Color { r: 1.0, g: 1.0, b: 1.0, a: 0.85 }
+                    Color {
+                        r: 1.0,
+                        g: 1.0,
+                        b: 1.0,
+                        a: 0.85,
+                    }
                 } else {
                     Color::default()
                 },
@@ -54,20 +61,16 @@ widget_component! {
             }),
             content_keep_aspect_ratio: Some(ImageBoxAspectRatio {
                 horizontal_alignment,
-                vertical_alignment: 0.5
+                vertical_alignment: 0.5,
             }),
             transform: Transform {
-                pivot: Vec2 {
-                    x: 0.5,
-                    y: 0.5,
-                },
+                pivot: Vec2 { x: 0.5, y: 0.5 },
                 scale,
                 ..Default::default()
             },
             ..Default::default()
         };
-        let button_props = Props::new(NavItemActive)
-            .with(ButtonNotifyProps(id.to_owned().into()));
+        let button_props = Props::new(NavItemActive).with(ButtonNotifyProps(id.to_owned().into()));
 
         widget! {
             (#{key} button: {button_props} {
@@ -75,4 +78,4 @@ widget_component! {
             })
         }
     }
-}
+);

--- a/demos/hello-world/src/ui/components/title_bar.rs
+++ b/demos/hello-world/src/ui/components/title_bar.rs
@@ -1,11 +1,18 @@
 use raui_core::prelude::*;
 
-widget_component! {
-    pub title_bar(id, key, state) [use_button_notified_state, use_text_input_notified_state] {
-        let ButtonProps { selected, trigger, .. } = state.read_cloned_or_default();
-        let TextInputProps { text, cursor_position, focused, .. } = state.read_cloned_or_default();
-        let text = text.trim();
-        let text = if text.is_empty() {
+widget_component!(
+    #[pre(use_button_notified_state, use_text_input_notified_state)]
+    pub fn title_bar(id: Id, key: Key, state: State) {
+        let ButtonProps {
+            selected, trigger, ..
+        } = state.read_cloned_or_default();
+        let TextInputProps {
+            text,
+            cursor_position,
+            focused,
+            ..
+        } = state.read_cloned_or_default();
+        let text = if text.trim().is_empty() {
             "> Focus here and start typing...".to_owned()
         } else if focused {
             if cursor_position < text.len() {
@@ -26,13 +33,33 @@ widget_component! {
                 size: 32.0,
             },
             color: if trigger {
-                Color { r: 1.0, g: 0.0, b: 0.0, a: 1.0 }
+                Color {
+                    r: 1.0,
+                    g: 0.0,
+                    b: 0.0,
+                    a: 1.0,
+                }
             } else if selected {
-                Color { r: 0.0, g: 1.0, b: 0.0, a: 1.0 }
+                Color {
+                    r: 0.0,
+                    g: 1.0,
+                    b: 0.0,
+                    a: 1.0,
+                }
             } else if focused {
-                Color { r: 0.0, g: 0.0, b: 1.0, a: 1.0 }
+                Color {
+                    r: 0.0,
+                    g: 0.0,
+                    b: 1.0,
+                    a: 1.0,
+                }
             } else {
-                Color { r: 0.0, g: 0.0, b: 0.0, a: 1.0 }
+                Color {
+                    r: 0.0,
+                    g: 0.0,
+                    b: 0.0,
+                    a: 1.0,
+                }
             },
             ..Default::default()
         };
@@ -46,4 +73,4 @@ widget_component! {
             })
         }
     }
-}
+);

--- a/demos/in-game/src/ui/components/app.rs
+++ b/demos/in-game/src/ui/components/app.rs
@@ -56,8 +56,9 @@ widget_hook! {
     }
 }
 
-widget_component! {
-    pub app(id, key, props, state) [use_nav_container_active, use_app] {
+widget_component!(
+    #[pre(use_nav_container_active, use_app)]
+    pub fn app(id: Id, key: Key, props: Props, state: State) {
         let shared_props = Props::new(AppSharedProps(id.to_owned())).with(new_theme());
         let minimap_props = ContentBoxItemLayout {
             anchors: Rect {
@@ -66,14 +67,8 @@ widget_component! {
                 top: 0.0,
                 bottom: 0.0,
             },
-            align: Vec2 {
-                x: 1.0,
-                y: 0.0,
-            },
-            offset: Vec2 {
-                x: -6.0,
-                y: 6.0,
-            },
+            align: Vec2 { x: 1.0, y: 0.0 },
+            offset: Vec2 { x: -6.0, y: 6.0 },
             ..Default::default()
         };
         let inventory_props = Props::new(ContentBoxItemLayout {
@@ -83,19 +78,17 @@ widget_component! {
                 top: 1.0,
                 bottom: 1.0,
             },
-            align: Vec2 {
-                x: 0.5,
-                y: 1.0,
-            },
-            offset: Vec2 {
-                x: 0.0,
-                y: -6.0,
-            },
+            align: Vec2 { x: 0.5, y: 1.0 },
+            offset: Vec2 { x: 0.0, y: -6.0 },
             ..Default::default()
-        }).with(ItemCellsProps {
-            items: (0..=18).map(|i| {
-                ItemCellProps { image: format!("icon-{}", i), thin: false }
-            }).collect::<Vec<_>>(),
+        })
+        .with(ItemCellsProps {
+            items: (0..=18)
+                .map(|i| ItemCellProps {
+                    image: format!("icon-{}", i),
+                    thin: false,
+                })
+                .collect::<Vec<_>>(),
         });
         let popup = match state.read::<AppState>() {
             Ok(data) => {
@@ -112,27 +105,25 @@ widget_component! {
                             bottom: 46.0,
                         },
                         ..Default::default()
-                    }).with(PopupProps {
-                        index,
-                        text,
-                    });
+                    })
+                    .with(PopupProps { index, text });
 
                     widget! {
                         (#{"popup"} popup: {popup_props})
                     }
                 } else {
-                    widget!{()}
+                    widget! {()}
                 }
             }
             Err(_) => {
-                widget!{()}
+                widget! {()}
             }
         };
 
-        widget!{(#{key} content_box: {props.clone()} | {shared_props} [
+        widget! {(#{key} content_box: {props.clone()} | {shared_props} [
             (#{"minimap"} minimap: {minimap_props})
             (#{"inventory"} inventory: {inventory_props})
             {popup}
         ])}
     }
-}
+);

--- a/demos/in-game/src/ui/components/inventory.rs
+++ b/demos/in-game/src/ui/components/inventory.rs
@@ -57,8 +57,9 @@ widget_hook! {
     }
 }
 
-widget_component! {
-    pub inventory(id, key, props, shared_props, state) [use_inventory] {
+widget_component!(
+    #[pre(use_inventory)]
+    pub fn inventory(id: Id, key: Key, props: Props, shared_props: SharedProps, state: State) {
         let ItemCellsProps { items } = props.read_cloned_or_default();
         let data = match state.read::<InventoryState>() {
             Ok(data) => *data,
@@ -67,7 +68,8 @@ widget_component! {
         let list_props = Props::new(PaperProps {
             frame: None,
             ..Default::default()
-        }).with(ContentBoxItemLayout {
+        })
+        .with(ContentBoxItemLayout {
             margin: Rect {
                 left: 5.0,
                 right: 5.0,
@@ -83,7 +85,11 @@ widget_component! {
                 grow: 0.0,
                 shrink: 0.0,
                 ..Default::default()
-            }).with(ItemCellProps { image: "icon-prev".to_owned(), thin: true });
+            })
+            .with(ItemCellProps {
+                image: "icon-prev".to_owned(),
+                thin: true,
+            });
             widget! {
                 (#{"prev"} item_cell: {item_props})
             }
@@ -94,9 +100,11 @@ widget_component! {
                 grow: 0.0,
                 shrink: 0.0,
                 ..Default::default()
-            }).with(ItemData {
+            })
+            .with(ItemData {
                 index: data.index + i,
-            }).with(item);
+            })
+            .with(item);
             children.push(widget! {
                 (#{i} item_cell: {item_props})
             });
@@ -106,7 +114,11 @@ widget_component! {
                 grow: 0.0,
                 shrink: 0.0,
                 ..Default::default()
-            }).with(ItemCellProps { image: "icon-next".to_owned(), thin: true });
+            })
+            .with(ItemCellProps {
+                image: "icon-next".to_owned(),
+                thin: true,
+            });
             widget! {
                 (#{"next"} item_cell: {item_props})
             }
@@ -118,4 +130,4 @@ widget_component! {
             })
         }
     }
-}
+);

--- a/demos/in-game/src/ui/components/item_cell.rs
+++ b/demos/in-game/src/ui/components/item_cell.rs
@@ -76,12 +76,14 @@ widget_hook! {
     }
 }
 
-widget_component! {
-    pub item_cell(id, key, props, animator) [use_item_cell] {
+widget_component!(
+    #[pre(use_item_cell)]
+    pub fn item_cell(id: Id, key: Key, props: Props, animator: Animator) {
         let ItemCellProps { image, thin } = props.read_cloned_or_default();
-        let button_props = props.clone()
-        .with(NavItemActive)
-        .with(ButtonNotifyProps(id.to_owned().into()));
+        let button_props = props
+            .clone()
+            .with(NavItemActive)
+            .with(ButtonNotifyProps(id.to_owned().into()));
         let size_props = SizeBoxProps {
             width: SizeBoxSizeValue::Exact(if thin { 18.0 } else { 24.0 }),
             height: SizeBoxSizeValue::Exact(24.0),
@@ -91,7 +93,7 @@ widget_component! {
                 top: 2.0,
                 bottom: 2.0,
             },
-            .. Default::default()
+            ..Default::default()
         };
         let panel_props = props.clone().with(PaperProps {
             variant: "cell".to_owned(),
@@ -108,7 +110,11 @@ widget_component! {
                 })
             }
         } else {
-            let scale = lerp(1.0, 1.5, (animator.value_progress_or_zero("", "click") * PI).sin());
+            let scale = lerp(
+                1.0,
+                1.5,
+                (animator.value_progress_or_zero("", "click") * PI).sin(),
+            );
             let image_props = Props::new(ImageBoxProps {
                 content_keep_aspect_ratio: Some(ImageBoxAspectRatio {
                     horizontal_alignment: 0.5,
@@ -124,7 +130,8 @@ widget_component! {
                     ..Default::default()
                 },
                 ..Default::default()
-            }).with(ContentBoxItemLayout {
+            })
+            .with(ContentBoxItemLayout {
                 margin: Rect {
                     left: 4.0,
                     right: 4.0,
@@ -145,4 +152,4 @@ widget_component! {
             }
         }
     }
-}
+);

--- a/demos/in-game/src/ui/components/minimap.rs
+++ b/demos/in-game/src/ui/components/minimap.rs
@@ -1,8 +1,8 @@
 use raui_core::prelude::*;
 use raui_material::prelude::*;
 
-widget_component! {
-    pub minimap(key, props) {
+widget_component!(
+    pub fn minimap(key: Key, props: Props) {
         let size_props = props.clone().with(SizeBoxProps {
             width: SizeBoxSizeValue::Exact(64.0),
             height: SizeBoxSizeValue::Exact(64.0),
@@ -24,7 +24,8 @@ widget_component! {
                 ..Default::default()
             }),
             ..Default::default()
-        }).with(ContentBoxItemLayout {
+        })
+        .with(ContentBoxItemLayout {
             margin: Rect {
                 left: 7.0,
                 right: 6.0,
@@ -42,4 +43,4 @@ widget_component! {
             })
         }
     }
-}
+);

--- a/demos/in-game/src/ui/components/popup.rs
+++ b/demos/in-game/src/ui/components/popup.rs
@@ -30,21 +30,24 @@ widget_hook! {
     }
 }
 
-widget_component! {
-    pub popup(id, key, props) [use_popup] {
+widget_component!(
+    #[pre(use_popup)]
+    pub fn popup(id: Id, key: Key, props: Props) {
         let PopupProps { index, text } = props.read_cloned_or_default::<PopupProps>();
         let button_props = Props::new(NavItemActive).with(ButtonNotifyProps(id.to_owned().into()));
-        let panel_props = props.clone().with(PaperProps {
-            frame: None,
-            ..Default::default()
-        })
-        .with(VerticalBoxProps {
-            separation: 10.0,
-            ..Default::default()
-        });
+        let panel_props = props
+            .clone()
+            .with(PaperProps {
+                frame: None,
+                ..Default::default()
+            })
+            .with(VerticalBoxProps {
+                separation: 10.0,
+                ..Default::default()
+            });
         let image_props = Props::new(ImageBoxProps {
-            width: ImageBoxSizeValue::Exact(48.0),
-            height: ImageBoxSizeValue::Exact(48.0),
+            width: ImageBoxSizeValue::Exact(70.0),
+            height: ImageBoxSizeValue::Exact(70.0),
             material: ImageBoxMaterial::Image(ImageBoxImage {
                 id: format!("icon-{}", index),
                 ..Default::default()
@@ -75,4 +78,4 @@ widget_component! {
             })
         }
     }
-}
+);

--- a/demos/todo-app/src/ui/components/app.rs
+++ b/demos/todo-app/src/ui/components/app.rs
@@ -147,7 +147,8 @@ widget_hook! {
 }
 
 widget_component! {
-    pub app(id, key, props, state) [use_nav_container_active, use_app] {
+    #[pre(use_nav_container_active, use_app)]
+    pub fn app(id: Id, key: Key, props: Props, state: State) {
         let (theme_mode, tasks) = state.map_or_default::<AppState, _, _>(|s| {
             (s.theme, s.tasks.clone())
         });

--- a/demos/todo-app/src/ui/components/app_bar.rs
+++ b/demos/todo-app/src/ui/components/app_bar.rs
@@ -71,7 +71,8 @@ widget_hook! {
 }
 
 widget_component! {
-    pub app_bar(id, key, props, shared_props, state) [use_app_bar] {
+    #[pre(use_app_bar)]
+    pub fn app_bar(id: Id, key: Key, props: Props, shared_props: SharedProps, state: State) {
         let theme_mode = shared_props.read_cloned_or_default::<ThemeModeProps>();
         let props = props.clone().with(VerticalBoxProps {
             separation: 10.0,

--- a/demos/todo-app/src/ui/components/tasks_list.rs
+++ b/demos/todo-app/src/ui/components/tasks_list.rs
@@ -67,8 +67,9 @@ widget_hook! {
     }
 }
 
-widget_component! {
-    pub task(id, key, props) [use_task] {
+widget_component!(
+    #[pre(use_task)]
+    pub fn task(id: Id, key: Key, props: Props) {
         let data = props.read_cloned_or_default::<TaskProps>();
         let checkbox_props = Props::new(FlexBoxItemLayout {
             fill: 0.0,
@@ -141,14 +142,18 @@ widget_component! {
             ])
         }
     }
-}
+);
 
-widget_component! {
-    pub tasks_list(key, props) {
+widget_component!(
+    pub fn tasks_list(key: Key, props: Props) {
         let TasksProps { tasks } = props.read_cloned_or_default();
-        let tasks = tasks.into_iter().enumerate().map(|(i, item)| {
-            widget! { (#{i} task: {item}) }
-        }).collect::<Vec<_>>();
+        let tasks = tasks
+            .into_iter()
+            .enumerate()
+            .map(|(i, item)| {
+                widget! { (#{i} task: {item}) }
+            })
+            .collect::<Vec<_>>();
         let props = props.clone().with(VerticalBoxProps {
             separation: 10.0,
             ..Default::default()
@@ -158,4 +163,4 @@ widget_component! {
             (#{key} vertical_box: {props} |[ tasks ]|)
         }
     }
-}
+);

--- a/raui-core/src/widget/component/containers/content_box.rs
+++ b/raui-core/src/widget/component/containers/content_box.rs
@@ -21,37 +21,38 @@ pub struct ContentBoxProps {
 }
 implement_props_data!(ContentBoxProps);
 
-widget_component! {
-    pub nav_content_box(key, props, listed_slots) [
-        use_nav_container_active,
-        use_nav_jump_direction_active,
-        use_nav_item,
-    ] {
-        let props = props.clone()
+widget_component!(
+    #[pre(use_nav_container_active, use_nav_jump_direction_active, use_nav_item)]
+    pub fn nav_content_box(key: Key, props: Props, listed_slots: ListedSlots) {
+        let props = props
+            .clone()
             .without::<NavContainerActive>()
             .without::<NavJumpActive>()
             .without::<NavItemActive>();
 
-        widget!{
+        widget! {
             (#{key} content_box: {props} |[listed_slots]|)
         }
     }
-}
+);
 
-widget_component! {
-    pub content_box(id, props, listed_slots) {
-        let ContentBoxProps { clipping, transform } = props.read_cloned_or_default();
-        let items = listed_slots.into_iter().filter_map(|slot| {
-            if let Some(props) = slot.props() {
-                let layout = props.read_cloned_or_default::<ContentBoxItemLayout>();
-                Some(ContentBoxItemNode {
-                    slot,
-                    layout,
-                })
-            } else {
-                None
-            }
-        }).collect::<Vec<_>>();
+widget_component!(
+    pub fn content_box(id: Id, props: Props, listed_slots: ListedSlots) {
+        let ContentBoxProps {
+            clipping,
+            transform,
+        } = props.read_cloned_or_default();
+        let items = listed_slots
+            .into_iter()
+            .filter_map(|slot| {
+                if let Some(props) = slot.props() {
+                    let layout = props.read_cloned_or_default::<ContentBoxItemLayout>();
+                    Some(ContentBoxItemNode { slot, layout })
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
 
         widget! {{{
             ContentBoxNode {
@@ -63,4 +64,4 @@ widget_component! {
             }
         }}}
     }
-}
+);

--- a/raui-core/src/widget/component/containers/flex_box.rs
+++ b/raui-core/src/widget/component/containers/flex_box.rs
@@ -25,42 +25,40 @@ pub struct FlexBoxProps {
 }
 implement_props_data!(FlexBoxProps);
 
-widget_component! {
-    pub nav_flex_box(key, props, listed_slots) [
-        use_nav_container_active,
-        use_nav_jump,
-        use_nav_item,
-    ] {
-        let props = props.clone()
+widget_component!(
+    #[pre(use_nav_container_active, use_nav_jump, use_nav_item)]
+    pub fn nav_flex_box(key: Key, props: Props, listed_slots: ListedSlots) {
+        let props = props
+            .clone()
             .without::<NavContainerActive>()
             .without::<NavJumpActive>()
             .without::<NavItemActive>();
 
-        widget!{
+        widget! {
             (#{key} flex_box: {props} |[listed_slots]|)
         }
     }
-}
+);
 
-widget_component! {
-    pub flex_box(id, props, listed_slots) {
+widget_component!(
+    pub fn flex_box(id: Id, props: Props, listed_slots: ListedSlots) {
         let FlexBoxProps {
             direction,
             separation,
             wrap,
             transform,
         } = props.read_cloned_or_default();
-        let items = listed_slots.into_iter().filter_map(|slot| {
-            if let Some(props) = slot.props() {
-                let layout = props.read_cloned_or_default::<FlexBoxItemLayout>();
-                Some(FlexBoxItemNode {
-                    slot,
-                    layout,
-                })
-            } else {
-                None
-            }
-        }).collect::<Vec<_>>();
+        let items = listed_slots
+            .into_iter()
+            .filter_map(|slot| {
+                if let Some(props) = slot.props() {
+                    let layout = props.read_cloned_or_default::<FlexBoxItemLayout>();
+                    Some(FlexBoxItemNode { slot, layout })
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
 
         widget! {{{
             FlexBoxNode {
@@ -74,4 +72,4 @@ widget_component! {
             }
         }}}
     }
-}
+);

--- a/raui-core/src/widget/component/containers/grid_box.rs
+++ b/raui-core/src/widget/component/containers/grid_box.rs
@@ -23,37 +23,39 @@ pub struct GridBoxProps {
 }
 implement_props_data!(GridBoxProps);
 
-widget_component! {
-    pub nav_grid_box(key, props, listed_slots) [
-        use_nav_container_active,
-        use_nav_jump_direction_active,
-        use_nav_item,
-    ] {
-        let props = props.clone()
+widget_component!(
+    #[pre(use_nav_container_active, use_nav_jump_direction_active, use_nav_item)]
+    pub fn nav_grid_box(key: Key, props: Props, listed_slots: ListedSlots) {
+        let props = props
+            .clone()
             .without::<NavContainerActive>()
             .without::<NavJumpActive>()
             .without::<NavItemActive>();
 
-        widget!{
+        widget! {
             (#{key} grid_box: {props} |[listed_slots]|)
         }
     }
-}
+);
 
-widget_component! {
-    pub grid_box(id, props, listed_slots) {
-        let GridBoxProps { cols, rows, transform } = props.read_cloned_or_default();
-        let items = listed_slots.into_iter().filter_map(|slot| {
-            if let Some(props) = slot.props() {
-                let layout = props.read_cloned_or_default::<GridBoxItemLayout>();
-                Some(GridBoxItemNode {
-                    slot,
-                    layout,
-                })
-            } else {
-                None
-            }
-        }).collect::<Vec<_>>();
+widget_component!(
+    pub fn grid_box(id: Id, props: Props, listed_slots: ListedSlots) {
+        let GridBoxProps {
+            cols,
+            rows,
+            transform,
+        } = props.read_cloned_or_default();
+        let items = listed_slots
+            .into_iter()
+            .filter_map(|slot| {
+                if let Some(props) = slot.props() {
+                    let layout = props.read_cloned_or_default::<GridBoxItemLayout>();
+                    Some(GridBoxItemNode { slot, layout })
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
 
         widget! {{{
             GridBoxNode {
@@ -66,4 +68,4 @@ widget_component! {
             }
         }}}
     }
-}
+);

--- a/raui-core/src/widget/component/containers/horizontal_box.rs
+++ b/raui-core/src/widget/component/containers/horizontal_box.rs
@@ -26,26 +26,32 @@ pub struct HorizontalBoxProps {
 }
 implement_props_data!(HorizontalBoxProps);
 
-widget_component! {
-    pub nav_horizontal_box(key, props, listed_slots) [
+widget_component!(
+    #[pre(
         use_nav_container_active,
         use_nav_jump_horizontal_step_active,
-        use_nav_item,
-    ] {
-        let props = props.clone()
+        use_nav_item
+    )]
+    pub fn nav_horizontal_box(key: Key, props: Props, listed_slots: ListedSlots) {
+        let props = props
+            .clone()
             .without::<NavContainerActive>()
             .without::<NavJumpActive>()
             .without::<NavItemActive>();
 
-        widget!{
+        widget! {
             (#{key} horizontal_box: {props} |[listed_slots]|)
         }
     }
-}
+);
 
-widget_component! {
-    pub horizontal_box(key, props, listed_slots) {
-        let HorizontalBoxProps { separation, reversed, transform } = props.read_cloned_or_default();
+widget_component!(
+    pub fn horizontal_box(key: Key, props: Props, listed_slots: ListedSlots) {
+        let HorizontalBoxProps {
+            separation,
+            reversed,
+            transform,
+        } = props.read_cloned_or_default();
         let props = props.clone().with(FlexBoxProps {
             direction: if reversed {
                 FlexBoxDirection::HorizontalRightToLeft
@@ -61,4 +67,4 @@ widget_component! {
             (#{key} flex_box: {props} |[ listed_slots ]|)
         }
     }
-}
+);

--- a/raui-core/src/widget/component/containers/scroll_box.rs
+++ b/raui-core/src/widget/component/containers/scroll_box.rs
@@ -1,6 +1,6 @@
 use crate::{
     props::Props,
-    unpack_named_slots, widget,
+    widget,
     widget::{
         component::{
             containers::content_box::content_box,
@@ -75,16 +75,15 @@ widget_hook! {
     }
 }
 
-widget_component! {
-    nav_scroll_box_content(id, named_slots) [
+widget_component!(
+    #[pre(
         use_resize_listener,
         use_nav_item_active,
         use_nav_container_active,
         use_nav_scroll_view_content,
-        use_nav_scroll_box_content,
-    ] {
-        unpack_named_slots!(named_slots => content);
-
+        use_nav_scroll_box_content
+    )]
+    fn nav_scroll_box_content(id: Id, (content,): NamedSlots) {
         widget! {{{
             AreaBoxNode {
                 id: id.to_owned(),
@@ -93,7 +92,7 @@ widget_component! {
             }
         }}}
     }
-}
+);
 
 widget_hook! {
     use_nav_scroll_box(life_cycle) {
@@ -111,16 +110,21 @@ widget_hook! {
     }
 }
 
-widget_component! {
-    pub nav_scroll_box(id, key, props, state, named_slots) [
+widget_component!(
+    #[pre(
         use_resize_listener,
         use_nav_item,
         use_nav_container_active,
         use_scroll_view,
-        use_nav_scroll_box,
-    ] {
-        unpack_named_slots!(named_slots => {content, scrollbars});
-
+        use_nav_scroll_box
+    )]
+    pub fn nav_scroll_box(
+        id: Id,
+        key: Key,
+        state: State,
+        props: Props,
+        (content, scrollbars): NamedSlots,
+    ) {
         let scroll_props = state.read_cloned_or_default::<ScrollViewState>();
         let content_props = Props::new(ContentBoxItemLayout {
             align: scroll_props.value,
@@ -141,7 +145,7 @@ widget_component! {
             ])
         }
     }
-}
+);
 
 widget_hook! {
     use_nav_scroll_box_side_scrollbars(life_cycle) {
@@ -181,12 +185,13 @@ widget_hook! {
     }
 }
 
-widget_component! {
-    pub nav_scroll_box_side_scrollbars(id, key, props) [
+widget_component!(
+    #[pre(
         use_nav_item_active,
         use_nav_container_active,
-        use_nav_scroll_box_side_scrollbars,
-    ] {
+        use_nav_scroll_box_side_scrollbars
+    )]
+    pub fn nav_scroll_box_side_scrollbars(id: Id, key: Key, props: Props) {
         let view_props = props.read_cloned_or_default::<ScrollViewState>();
         let SideScrollbarsProps {
             size,
@@ -195,24 +200,24 @@ widget_component! {
         } = props.read_cloned_or_default();
         let hbar = if view_props.size_factor.x > 1.0 {
             let props = Props::new(ButtonNotifyProps(id.to_owned().into()))
-            .with(NavItemActive)
-            .with(NavButtonTrackingActive)
-            .with(ContentBoxItemLayout {
-                anchors: Rect {
-                    left: 0.0,
-                    right: 1.0,
-                    top: 1.0,
-                    bottom: 1.0,
-                },
-                margin: Rect {
-                    left: 0.0,
-                    right: size,
-                    top: -size,
-                    bottom: 0.0,
-                },
-                align: Vec2 { x: 0.0, y: 1.0 },
-                ..Default::default()
-            });
+                .with(NavItemActive)
+                .with(NavButtonTrackingActive)
+                .with(ContentBoxItemLayout {
+                    anchors: Rect {
+                        left: 0.0,
+                        right: 1.0,
+                        top: 1.0,
+                        bottom: 1.0,
+                    },
+                    margin: Rect {
+                        left: 0.0,
+                        right: size,
+                        top: -size,
+                        bottom: 0.0,
+                    },
+                    align: Vec2 { x: 0.0, y: 1.0 },
+                    ..Default::default()
+                });
             let front_props = ImageBoxProps {
                 material: front_material.clone(),
                 ..Default::default()
@@ -223,9 +228,9 @@ widget_component! {
                     ..Default::default()
                 };
 
-                widget!{ (#{"back"} image_box: {props}) }
+                widget! { (#{"back"} image_box: {props}) }
             } else {
-                widget!{()}
+                widget! {()}
             };
 
             widget! {
@@ -237,37 +242,37 @@ widget_component! {
                 })
             }
         } else {
-            widget!{()}
+            widget! {()}
         };
         let vbar = if view_props.size_factor.y > 1.0 {
             let props = Props::new(ButtonNotifyProps(id.to_owned().into()))
-            .with(NavItemActive)
-            .with(NavButtonTrackingActive)
-            .with(ContentBoxItemLayout {
-                anchors: Rect {
-                    left: 1.0,
-                    right: 1.0,
-                    top: 0.0,
-                    bottom: 1.0,
-                },
-                margin: Rect {
-                    left: -size,
-                    right: 0.0,
-                    top: 0.0,
-                    bottom: size,
-                },
-                align: Vec2 { x: 1.0, y: 0.0 },
-                ..Default::default()
-            });
+                .with(NavItemActive)
+                .with(NavButtonTrackingActive)
+                .with(ContentBoxItemLayout {
+                    anchors: Rect {
+                        left: 1.0,
+                        right: 1.0,
+                        top: 0.0,
+                        bottom: 1.0,
+                    },
+                    margin: Rect {
+                        left: -size,
+                        right: 0.0,
+                        top: 0.0,
+                        bottom: size,
+                    },
+                    align: Vec2 { x: 1.0, y: 0.0 },
+                    ..Default::default()
+                });
             let back = if let Some(material) = back_material {
                 let props = ImageBoxProps {
                     material,
                     ..Default::default()
                 };
 
-                widget!{ (#{"back"} image_box: {props}) }
+                widget! { (#{"back"} image_box: {props}) }
             } else {
-                widget!{()}
+                widget! {()}
             };
             let front_props = ImageBoxProps {
                 material: front_material,
@@ -283,7 +288,7 @@ widget_component! {
                 })
             }
         } else {
-            widget!{()}
+            widget! {()}
         };
 
         widget! {
@@ -293,4 +298,4 @@ widget_component! {
             ])
         }
     }
-}
+);

--- a/raui-core/src/widget/component/containers/size_box.rs
+++ b/raui-core/src/widget/component/containers/size_box.rs
@@ -1,5 +1,5 @@
 use crate::{
-    unpack_named_slots, widget,
+    widget,
     widget::{
         unit::size::{SizeBoxNode, SizeBoxSizeValue},
         utils::{Rect, Transform},
@@ -21,10 +21,14 @@ pub struct SizeBoxProps {
 }
 implement_props_data!(SizeBoxProps);
 
-widget_component! {
-    pub size_box(id, props, named_slots) {
-        unpack_named_slots!(named_slots => content);
-        let SizeBoxProps { width, height, margin, transform } = props.read_cloned_or_default();
+widget_component!(
+    pub fn size_box(id: Id, props: Props, (content,): NamedSlots) {
+        let SizeBoxProps {
+            width,
+            height,
+            margin,
+            transform,
+        } = props.read_cloned_or_default();
 
         widget! {{{
             SizeBoxNode {
@@ -38,4 +42,4 @@ widget_component! {
             }
         }}}
     }
-}
+);

--- a/raui-core/src/widget/component/containers/switch_box.rs
+++ b/raui-core/src/widget/component/containers/switch_box.rs
@@ -24,34 +24,34 @@ pub struct SwitchBoxProps {
 }
 implement_props_data!(SwitchBoxProps);
 
-widget_component! {
-    pub nav_switch_box(key, props, listed_slots) [
-        use_nav_container_active,
-        use_nav_jump_step_pages_active,
-        use_nav_item,
-    ] {
-        let props = props.clone()
+widget_component!(
+    #[pre(use_nav_container_active, use_nav_jump_step_pages_active, use_nav_item)]
+    pub fn nav_switch_box(key: Key, props: Props, listed_slots: ListedSlots) {
+        let props = props
+            .clone()
             .without::<NavContainerActive>()
             .without::<NavJumpActive>()
             .without::<NavItemActive>();
 
-        widget!{
+        widget! {
             (#{key} switch_box: {props} |[listed_slots]|)
         }
     }
-}
+);
 
-widget_component! {
-    pub switch_box(id, props, listed_slots) {
-        let SwitchBoxProps { active_index, clipping, transform } = props.read_cloned_or_default();
+widget_component!(
+    pub fn switch_box(id: Id, props: Props, listed_slots: ListedSlots) {
+        let SwitchBoxProps {
+            active_index,
+            clipping,
+            transform,
+        } = props.read_cloned_or_default();
         let items = if let Some(index) = active_index {
             if let Some(slot) = listed_slots.into_iter().nth(index) {
-                vec![
-                    ContentBoxItemNode {
-                        slot,
-                        ..Default::default()
-                    }
-                ]
+                vec![ContentBoxItemNode {
+                    slot,
+                    ..Default::default()
+                }]
             } else {
                 vec![]
             }
@@ -69,4 +69,4 @@ widget_component! {
             }
         }}}
     }
-}
+);

--- a/raui-core/src/widget/component/containers/variant_box.rs
+++ b/raui-core/src/widget/component/containers/variant_box.rs
@@ -9,8 +9,8 @@ pub struct VariantBoxProps {
 }
 implement_props_data!(VariantBoxProps);
 
-widget_component! {
-    pub variant_box(props, named_slots) {
+widget_component!(
+    pub fn variant_box(props: Props, named_slots: NamedSlots) {
         let VariantBoxProps { variant_name } = props.read_cloned_or_default();
         if let Some(variant_name) = variant_name {
             named_slots.remove(&variant_name).unwrap_or_default()
@@ -18,4 +18,4 @@ widget_component! {
             Default::default()
         }
     }
-}
+);

--- a/raui-core/src/widget/component/containers/vertical_box.rs
+++ b/raui-core/src/widget/component/containers/vertical_box.rs
@@ -26,26 +26,32 @@ pub struct VerticalBoxProps {
 }
 implement_props_data!(VerticalBoxProps);
 
-widget_component! {
-    pub nav_vertical_box(key, props, listed_slots) [
+widget_component!(
+    #[pre(
         use_nav_container_active,
         use_nav_jump_vertical_step_active,
-        use_nav_item,
-    ] {
-        let props = props.clone()
+        use_nav_item
+    )]
+    pub fn nav_vertical_box(key: Key, props: Props, listed_slots: ListedSlots) {
+        let props = props
+            .clone()
             .without::<NavContainerActive>()
             .without::<NavJumpActive>()
             .without::<NavItemActive>();
 
-        widget!{
+        widget! {
             (#{key} vertical_box: {props} |[listed_slots]|)
         }
     }
-}
+);
 
-widget_component! {
-    pub vertical_box(key, props, listed_slots) {
-        let VerticalBoxProps { separation, reversed, transform } = props.read_cloned_or_default();
+widget_component!(
+    pub fn vertical_box(key: Key, props: Props, listed_slots: ListedSlots) {
+        let VerticalBoxProps {
+            separation,
+            reversed,
+            transform,
+        } = props.read_cloned_or_default();
         let props = props.clone().with(FlexBoxProps {
             direction: if reversed {
                 FlexBoxDirection::VerticalBottomToTop
@@ -61,4 +67,4 @@ widget_component! {
             (#{key} flex_box: {props} |[ listed_slots ]|)
         }
     }
-}
+);

--- a/raui-core/src/widget/component/containers/wrap_box.rs
+++ b/raui-core/src/widget/component/containers/wrap_box.rs
@@ -1,5 +1,5 @@
 use crate::{
-    unpack_named_slots, widget,
+    widget,
     widget::{unit::size::SizeBoxNode, utils::Rect},
     widget_component,
 };
@@ -12,13 +12,12 @@ pub struct WrapBoxProps {
 }
 implement_props_data!(WrapBoxProps);
 
-widget_component! {
-    pub wrap_box(id, props, named_slots) {
-        unpack_named_slots!(named_slots => content);
+widget_component!(
+    pub fn wrap_box(id: Id, props: Props, (content,): NamedSlots) {
         let WrapBoxProps { margin } = props.read_cloned_or_default();
 
         widget! {{{
-            SizeBoxNode {
+                SizeBoxNode {
                 id: id.to_owned(),
                 props: props.clone(),
                 slot: Box::new(content),
@@ -27,4 +26,4 @@ widget_component! {
             }
         }}}
     }
-}
+);

--- a/raui-core/src/widget/component/image_box.rs
+++ b/raui-core/src/widget/component/image_box.rs
@@ -25,8 +25,8 @@ pub struct ImageBoxProps {
 }
 implement_props_data!(ImageBoxProps);
 
-widget_component! {
-    pub image_box(id, props, shared_props) {
+widget_component!(
+    pub fn image_box(id: Id, props: Props, shared_props: SharedProps) {
         let ImageBoxProps {
             width,
             height,
@@ -57,4 +57,4 @@ widget_component! {
             }
         }}}
     }
-}
+);

--- a/raui-core/src/widget/component/interactive/button.rs
+++ b/raui-core/src/widget/component/interactive/button.rs
@@ -1,6 +1,6 @@
 use crate::{
     messenger::MessageData,
-    unpack_named_slots, widget,
+    widget,
     widget::{
         component::interactive::navigation::{use_nav_button, use_nav_item, NavSignal},
         context::WidgetMountOrChangeContext,
@@ -175,10 +175,9 @@ widget_hook! {
     }
 }
 
-widget_component! {
-    pub button(id, state, named_slots) [use_nav_item, use_button] {
-        unpack_named_slots!(named_slots => content);
-
+widget_component!(
+    #[pre(use_nav_item, use_button)]
+    pub fn button(id: Id, state: State, (content,): NamedSlots) {
         if let Some(p) = content.props_mut() {
             p.write(state.read_cloned_or_default::<ButtonProps>());
         }
@@ -191,4 +190,4 @@ widget_component! {
             }
         }}}
     }
-}
+);

--- a/raui-core/src/widget/component/interactive/input_field.rs
+++ b/raui-core/src/widget/component/interactive/input_field.rs
@@ -1,6 +1,6 @@
 use crate::{
     messenger::MessageData,
-    unpack_named_slots, widget,
+    widget,
     widget::{
         component::interactive::{
             button::{use_button, ButtonProps},
@@ -176,10 +176,9 @@ widget_hook! {
     }
 }
 
-widget_component! {
-    pub text_input(id, state, named_slots) [use_nav_item, use_text_input] {
-        unpack_named_slots!(named_slots => content);
-
+widget_component!(
+    #[pre(use_nav_item, use_text_input)]
+    pub fn text_input(id: Id, state: State, (content,): NamedSlots) {
         if let Some(p) = content.props_mut() {
             p.write(state.read_cloned_or_default::<TextInputProps>());
         }
@@ -192,12 +191,11 @@ widget_component! {
             }
         }}}
     }
-}
+);
 
-widget_component! {
-    pub input_field(id, state, named_slots) [use_nav_item, use_input_field] {
-        unpack_named_slots!(named_slots => content);
-
+widget_component!(
+    #[pre(use_nav_item, use_input_field)]
+    pub fn input_field(id: Id, state: State, (content,): NamedSlots) {
         if let Some(p) = content.props_mut() {
             p.write(state.read_cloned_or_default::<ButtonProps>());
             p.write(state.read_cloned_or_default::<TextInputProps>());
@@ -211,4 +209,4 @@ widget_component! {
             }
         }}}
     }
-}
+);

--- a/raui-core/src/widget/component/space_box.rs
+++ b/raui-core/src/widget/component/space_box.rs
@@ -14,8 +14,8 @@ pub struct SpaceBoxProps {
 }
 implement_props_data!(SpaceBoxProps);
 
-widget_component! {
-    pub space_box(id, props) {
+widget_component!(
+    pub fn space_box(id: Id, props: Props) {
         let SpaceBoxProps { width, height } = props.read_cloned_or_default();
 
         widget! {{{
@@ -28,4 +28,4 @@ widget_component! {
             }
         }}}
     }
-}
+);

--- a/raui-core/src/widget/component/text_box.rs
+++ b/raui-core/src/widget/component/text_box.rs
@@ -32,8 +32,8 @@ pub struct TextBoxProps {
 }
 implement_props_data!(TextBoxProps);
 
-widget_component! {
-    pub text_box(id, props, shared_props) {
+widget_component!(
+    pub fn text_box(id: Id, props: Props, shared_props: SharedProps) {
         let TextBoxProps {
             width,
             height,
@@ -62,4 +62,4 @@ widget_component! {
             }
         }}}
     }
-}
+);

--- a/raui-core/src/widget/unit/area.rs
+++ b/raui-core/src/widget/unit/area.rs
@@ -1,10 +1,13 @@
-use crate::{Scalar, widget::{
-    node::{WidgetNode, WidgetNodePrefab},
-    unit::{WidgetUnit, WidgetUnitData},
-    WidgetId,
-}};
+use crate::{
+    widget::{
+        node::{WidgetNode, WidgetNodePrefab},
+        unit::{WidgetUnit, WidgetUnitData},
+        WidgetId,
+    },
+    Scalar,
+};
 use serde::{Deserialize, Serialize};
-use std::{convert::TryFrom};
+use std::convert::TryFrom;
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct AreaBoxRendererEffect {

--- a/raui-material/src/component/containers/flex_paper.rs
+++ b/raui-material/src/component/containers/flex_paper.rs
@@ -1,22 +1,22 @@
 use crate::component::containers::paper::paper;
 use raui_core::prelude::*;
 
-widget_component! {
-    pub nav_flex_paper(key, props, listed_slots) {
+widget_component!(
+    pub fn nav_flex_paper(key: Key, props: Props, listed_slots: ListedSlots) {
         widget! {
             (#{key} paper: {props.clone()} [
                 (#{"flex"} nav_flex_box: {props.clone()} |[ listed_slots ]|)
             ])
         }
     }
-}
+);
 
-widget_component! {
-    pub flex_paper(key, props, listed_slots) {
+widget_component!(
+    pub fn flex_paper(key: Key, props: Props, listed_slots: ListedSlots) {
         widget! {
             (#{key} paper: {props.clone()} [
                 (#{"flex"} flex_box: {props.clone()} |[ listed_slots ]|)
             ])
         }
     }
-}
+);

--- a/raui-material/src/component/containers/grid_paper.rs
+++ b/raui-material/src/component/containers/grid_paper.rs
@@ -1,22 +1,22 @@
 use crate::component::containers::paper::paper;
 use raui_core::prelude::*;
 
-widget_component! {
-    pub nav_grid_paper(key, props, listed_slots) {
+widget_component!(
+    pub fn nav_grid_paper(key: Key, props: Props, listed_slots: ListedSlots) {
         widget! {
             (#{key} paper: {props.clone()} [
                 (#{"grid"} nav_grid_box: {props.clone()} |[ listed_slots ]|)
             ])
         }
     }
-}
+);
 
-widget_component! {
-    pub grid_paper(key, props, listed_slots) {
+widget_component!(
+    pub fn grid_paper(key: Key, props: Props, listed_slots: ListedSlots) {
         widget! {
             (#{key} paper: {props.clone()} [
                 (#{"grid"} grid_box: {props.clone()} |[ listed_slots ]|)
             ])
         }
     }
-}
+);

--- a/raui-material/src/component/containers/horizontal_paper.rs
+++ b/raui-material/src/component/containers/horizontal_paper.rs
@@ -2,7 +2,7 @@ use crate::component::containers::paper::paper;
 use raui_core::prelude::*;
 
 widget_component! {
-    pub nav_horizontal_paper(key, props, listed_slots) {
+    pub fn nav_horizontal_paper(key: Key, props: Props, listed_slots: ListedSlots) {
         widget! {
             (#{key} paper: {props.clone()} [
                 (#{"horizontal"} nav_horizontal_box: {props.clone()} |[ listed_slots ]|)
@@ -12,7 +12,7 @@ widget_component! {
 }
 
 widget_component! {
-    pub horizontal_paper(key, props, listed_slots) {
+    pub fn horizontal_paper(key: Key, props: Props, listed_slots: ListedSlots) {
         widget! {
             (#{key} paper: {props.clone()} [
                 (#{"horizontal"} horizontal_box: {props.clone()} |[ listed_slots ]|)

--- a/raui-material/src/component/containers/paper.rs
+++ b/raui-material/src/component/containers/paper.rs
@@ -28,8 +28,8 @@ impl Default for PaperProps {
     }
 }
 
-widget_component! {
-    pub paper(key, props, shared_props, listed_slots) {
+widget_component!(
+    pub fn paper(key: Key, props: Props, shared_props: SharedProps, listed_slots: ListedSlots) {
         let paper_props = props.read_cloned_or_default::<PaperProps>();
         let themed_props = props.read_cloned_or_default::<ThemedWidgetProps>();
 
@@ -43,9 +43,8 @@ widget_component! {
                         .cloned()
                         .unwrap_or_default()
                 });
-                let background_colors = shared_props.map_or_default::<ThemeProps, _, _>(|props| {
-                    props.background_colors.clone()
-                });
+                let background_colors = shared_props
+                    .map_or_default::<ThemeProps, _, _>(|props| props.background_colors.clone());
                 let image = match content_background {
                     ThemedImageMaterial::Color => {
                         let color = match themed_props.color {
@@ -61,23 +60,20 @@ widget_component! {
                             ..Default::default()
                         }
                     }
-                    ThemedImageMaterial::Image(material) => {
-                        ImageBoxProps {
-                            material: ImageBoxMaterial::Image(material),
-                            ..Default::default()
-                        }
-                    }
-                    ThemedImageMaterial::Procedural(material) => {
-                        ImageBoxProps {
-                            material: ImageBoxMaterial::Procedural(material),
-                            ..Default::default()
-                        }
-                    }
+                    ThemedImageMaterial::Image(material) => ImageBoxProps {
+                        material: ImageBoxMaterial::Image(material),
+                        ..Default::default()
+                    },
+                    ThemedImageMaterial::Procedural(material) => ImageBoxProps {
+                        material: ImageBoxMaterial::Procedural(material),
+                        ..Default::default()
+                    },
                 };
                 let props = Props::new(ContentBoxItemLayout {
                     depth: Scalar::NEG_INFINITY,
                     ..Default::default()
-                }).with(image);
+                })
+                .with(image);
                 let background = widget! {
                     (#{"background"} image_box: {props})
                 };
@@ -90,7 +86,8 @@ widget_component! {
                     let props = Props::new(ContentBoxItemLayout {
                         depth: Scalar::NEG_INFINITY,
                         ..Default::default()
-                    }).with(ImageBoxProps {
+                    })
+                    .with(ImageBoxProps {
                         material: ImageBoxMaterial::Color(ImageBoxColor {
                             color,
                             scaling: ImageBoxImageScaling::Frame(frame),
@@ -109,12 +106,13 @@ widget_component! {
                         .chain(listed_slots.into_iter())
                         .collect::<Vec<_>>()
                 }
-            },
+            }
             ThemeVariant::Outline => {
                 if let Some(frame) = paper_props.frame {
-                    let background_colors = shared_props.map_or_default::<ThemeProps, _, _>(|props| {
-                        props.background_colors.clone()
-                    });
+                    let background_colors =
+                        shared_props.map_or_default::<ThemeProps, _, _>(|props| {
+                            props.background_colors.clone()
+                        });
                     let color = match themed_props.color {
                         ThemeColor::Default => background_colors.main.default.dark,
                         ThemeColor::Primary => background_colors.main.primary.dark,
@@ -123,7 +121,8 @@ widget_component! {
                     let props = Props::new(ContentBoxItemLayout {
                         depth: Scalar::NEG_INFINITY,
                         ..Default::default()
-                    }).with(ImageBoxProps {
+                    })
+                    .with(ImageBoxProps {
                         material: ImageBoxMaterial::Color(ImageBoxColor {
                             color,
                             scaling: ImageBoxImageScaling::Frame(frame),
@@ -139,11 +138,11 @@ widget_component! {
                 } else {
                     listed_slots
                 }
-            },
+            }
         };
 
         widget! {
             (#{key} content_box: {props.clone()} |[ items ]|)
         }
     }
-}
+);

--- a/raui-material/src/component/containers/vertical_paper.rs
+++ b/raui-material/src/component/containers/vertical_paper.rs
@@ -1,22 +1,22 @@
 use crate::component::containers::paper::paper;
 use raui_core::prelude::*;
 
-widget_component! {
-    pub nav_vertical_paper(key, props, listed_slots) {
+widget_component!(
+    pub fn nav_vertical_paper(key: Key, props: Props, listed_slots: ListedSlots) {
         widget! {
             (#{key} paper: {props.clone()} [
                 (#{"vertical"} nav_vertical_box: {props.clone()} |[ listed_slots ]|)
             ])
         }
     }
-}
+);
 
-widget_component! {
-    pub vertical_paper(key, props, listed_slots) {
+widget_component!(
+    pub fn vertical_paper(key: Key, props: Props, listed_slots: ListedSlots) {
         widget! {
             (#{key} paper: {props.clone()} [
                 (#{"vertical"} vertical_box: {props.clone()} |[ listed_slots ]|)
             ])
         }
     }
-}
+);

--- a/raui-material/src/component/containers/wrap_paper.rs
+++ b/raui-material/src/component/containers/wrap_paper.rs
@@ -1,10 +1,8 @@
 use crate::component::containers::paper::paper;
 use raui_core::prelude::*;
 
-widget_component! {
-    pub wrap_paper(key, props, named_slots) {
-        unpack_named_slots!(named_slots => content);
-
+widget_component!(
+    pub fn wrap_paper(key: Key, props: Props, (content,): NamedSlots) {
         widget! {
             (#{key} paper: {props.clone()} [
                 (#{"wrap"} wrap_box: {props.clone()} {
@@ -13,4 +11,4 @@ widget_component! {
             ])
         }
     }
-}
+);

--- a/raui-material/src/component/icon_paper.rs
+++ b/raui-material/src/component/icon_paper.rs
@@ -24,8 +24,8 @@ pub struct IconPaperProps {
 }
 implement_props_data!(IconPaperProps);
 
-widget_component! {
-    pub icon_paper(key, props, shared_props) {
+widget_component!(
+    pub fn icon_paper(key: Key, props: Props, shared_props: SharedProps) {
         let themed_props = props.read_cloned_or_default::<ThemedWidgetProps>();
         let tint = match shared_props.read::<ThemeProps>() {
             Ok(props) => match themed_props.color {
@@ -44,7 +44,11 @@ widget_component! {
                 .unwrap_or(24.0),
             Err(_) => 24.0,
         };
-        let IconImage {id, source_rect, scaling } = icon_props.image;
+        let IconImage {
+            id,
+            source_rect,
+            scaling,
+        } = icon_props.image;
         let image = ImageBoxImage {
             id,
             source_rect,
@@ -66,4 +70,4 @@ widget_component! {
             (#{key} image_box: {props})
         }
     }
-}
+);

--- a/raui-material/src/component/interactive/button_paper.rs
+++ b/raui-material/src/component/interactive/button_paper.rs
@@ -4,10 +4,14 @@ use crate::{
 };
 use raui_core::prelude::*;
 
-widget_component! {
-    button_paper_content(id, key, props, shared_props, named_slots) {
-        unpack_named_slots!(named_slots => content);
-
+widget_component!(
+    fn button_paper_content(
+        id: Id,
+        key: Key,
+        props: Props,
+        shared_props: SharedProps,
+        (content,): NamedSlots,
+    ) {
         let button_props = props.read_cloned_or_default::<ButtonProps>();
         let paper_props = props.read_cloned_or_default::<PaperProps>();
         let themed_props = props.read_cloned_or_default::<ThemedWidgetProps>();
@@ -15,34 +19,32 @@ widget_component! {
         let items = match themed_props.variant {
             ThemeVariant::ContentOnly => vec![content],
             ThemeVariant::Filled => {
-                let button_background = shared_props
-                    .map_or_default::<ThemeProps, _, _>(|props| {
-                        if button_props.trigger || button_props.context {
-                            props
-                                .button_backgrounds
-                                .get(&paper_props.variant)
-                                .cloned()
-                                .unwrap_or_default()
-                                .trigger
-                        } else if button_props.selected {
-                            props
-                                .button_backgrounds
-                                .get(&paper_props.variant)
-                                .cloned()
-                                .unwrap_or_default()
-                                .selected
-                        } else {
-                            props
-                                .button_backgrounds
-                                .get(&paper_props.variant)
-                                .cloned()
-                                .unwrap_or_default()
-                                .default
-                        }
-                    });
-                let button_colors = shared_props.map_or_default::<ThemeProps, _, _>(|props| {
-                    props.active_colors.clone()
+                let button_background = shared_props.map_or_default::<ThemeProps, _, _>(|props| {
+                    if button_props.trigger || button_props.context {
+                        props
+                            .button_backgrounds
+                            .get(&paper_props.variant)
+                            .cloned()
+                            .unwrap_or_default()
+                            .trigger
+                    } else if button_props.selected {
+                        props
+                            .button_backgrounds
+                            .get(&paper_props.variant)
+                            .cloned()
+                            .unwrap_or_default()
+                            .selected
+                    } else {
+                        props
+                            .button_backgrounds
+                            .get(&paper_props.variant)
+                            .cloned()
+                            .unwrap_or_default()
+                            .default
+                    }
                 });
+                let button_colors = shared_props
+                    .map_or_default::<ThemeProps, _, _>(|props| props.active_colors.clone());
                 let image = match button_background {
                     ThemedImageMaterial::Color => {
                         let color = match themed_props.color {
@@ -58,23 +60,20 @@ widget_component! {
                             ..Default::default()
                         }
                     }
-                    ThemedImageMaterial::Image(material) => {
-                        ImageBoxProps {
-                            material: ImageBoxMaterial::Image(material),
-                            ..Default::default()
-                        }
-                    }
-                    ThemedImageMaterial::Procedural(material) => {
-                        ImageBoxProps {
-                            material: ImageBoxMaterial::Procedural(material),
-                            ..Default::default()
-                        }
-                    }
+                    ThemedImageMaterial::Image(material) => ImageBoxProps {
+                        material: ImageBoxMaterial::Image(material),
+                        ..Default::default()
+                    },
+                    ThemedImageMaterial::Procedural(material) => ImageBoxProps {
+                        material: ImageBoxMaterial::Procedural(material),
+                        ..Default::default()
+                    },
                 };
                 let props = Props::new(ContentBoxItemLayout {
                     depth: Scalar::NEG_INFINITY,
                     ..Default::default()
-                }).with(image);
+                })
+                .with(image);
                 let background = widget! {
                     (#{"background"} image_box: {props})
                 };
@@ -87,7 +86,8 @@ widget_component! {
                     let props = Props::new(ContentBoxItemLayout {
                         depth: Scalar::NEG_INFINITY,
                         ..Default::default()
-                    }).with(ImageBoxProps {
+                    })
+                    .with(ImageBoxProps {
                         material: ImageBoxMaterial::Color(ImageBoxColor {
                             color,
                             scaling: ImageBoxImageScaling::Frame(frame),
@@ -101,12 +101,11 @@ widget_component! {
                 } else {
                     vec![background, content]
                 }
-            },
+            }
             ThemeVariant::Outline => {
                 if let Some(frame) = paper_props.frame {
-                    let button_colors = shared_props.map_or_default::<ThemeProps, _, _>(|props| {
-                        props.active_colors.clone()
-                    });
+                    let button_colors = shared_props
+                        .map_or_default::<ThemeProps, _, _>(|props| props.active_colors.clone());
                     let color = match themed_props.color {
                         ThemeColor::Default => button_colors.main.default.dark,
                         ThemeColor::Primary => button_colors.main.primary.dark,
@@ -115,7 +114,8 @@ widget_component! {
                     let props = Props::new(ContentBoxItemLayout {
                         depth: Scalar::NEG_INFINITY,
                         ..Default::default()
-                    }).with(ImageBoxProps {
+                    })
+                    .with(ImageBoxProps {
                         material: ImageBoxMaterial::Color(ImageBoxColor {
                             color,
                             scaling: ImageBoxImageScaling::Frame(frame),
@@ -129,19 +129,17 @@ widget_component! {
                 } else {
                     vec![content]
                 }
-            },
+            }
         };
 
         widget! {
             (#{key} content_box: {props.clone()} |[ items ]|)
         }
     }
-}
+);
 
-widget_component! {
-    pub button_paper(key, props, named_slots) {
-        unpack_named_slots!(named_slots => content);
-
+widget_component!(
+    pub fn button_paper(key: Key, props: Props, (content,): NamedSlots) {
         widget! {
             (#{key} button: {props.clone()} {
                 content = (#{"content"} button_paper_content: {props.clone()} {
@@ -150,4 +148,4 @@ widget_component! {
             })
         }
     }
-}
+);

--- a/raui-material/src/component/interactive/icon_button_paper.rs
+++ b/raui-material/src/component/interactive/icon_button_paper.rs
@@ -1,11 +1,11 @@
 use crate::component::{icon_paper::icon_paper, interactive::button_paper::button_paper};
 
-widget_component! {
-    pub icon_button_paper(key, props) {
+widget_component!(
+    pub fn icon_button_paper(key: Key, props: Props) {
         widget! {
             (#{key} button_paper: {props.clone()} {
                 content = (#{"icon"} icon_paper: {props.clone()})
             })
         }
     }
-}
+);

--- a/raui-material/src/component/interactive/switch_button_paper.rs
+++ b/raui-material/src/component/interactive/switch_button_paper.rs
@@ -1,11 +1,11 @@
 use crate::component::{interactive::button_paper::button_paper, switch_paper::switch_paper};
 
-widget_component! {
-    pub switch_button_paper(key, props) {
+widget_component!(
+    pub fn switch_button_paper(key: Key, props: Props) {
         widget! {
             (#{key} button_paper: {props.clone()} {
                 content = (#{"switch"} switch_paper: {props.clone()})
             })
         }
     }
-}
+);

--- a/raui-material/src/component/interactive/text_button_paper.rs
+++ b/raui-material/src/component/interactive/text_button_paper.rs
@@ -1,11 +1,11 @@
 use crate::component::{interactive::button_paper::button_paper, text_paper::text_paper};
 
-widget_component! {
-    pub text_button_paper(key, props) {
+widget_component!(
+    pub fn text_button_paper(key: Key, props: Props) {
         widget! {
             (#{key} button_paper: {props.clone()} {
                 content = (#{"text"} text_paper: {props.clone()})
             })
         }
     }
-}
+);

--- a/raui-material/src/component/interactive/text_field_paper.rs
+++ b/raui-material/src/component/interactive/text_field_paper.rs
@@ -66,8 +66,8 @@ impl Default for TextFieldPaperProps {
     }
 }
 
-widget_component! {
-    text_field_paper_content(key, props) {
+widget_component!(
+    fn text_field_paper_content(key: Key, props: Props) {
         let TextFieldPaperProps {
             hint,
             width,
@@ -80,7 +80,12 @@ widget_component! {
             paper_theme,
             padding,
         } = props.read_cloned_or_default();
-        let TextInputProps { text, cursor_position, focused, .. } = props.read_cloned_or_default();
+        let TextInputProps {
+            text,
+            cursor_position,
+            focused,
+            ..
+        } = props.read_cloned_or_default();
         let text = text.trim();
         let text = if text.is_empty() {
             hint
@@ -94,22 +99,28 @@ widget_component! {
             text.to_owned()
         };
         let paper_variant = props.map_or_default::<PaperProps, _, _>(|p| p.variant.clone());
-        let paper_props = props.clone().with(PaperProps {
-            variant: paper_variant,
-            ..Default::default()
-        }).with(paper_theme);
-        let text_props = props.clone().with(TextPaperProps {
-            text,
-            width,
-            height,
-            variant,
-            use_main_color,
-            alignment_override,
-            transform,
-        }).with(ContentBoxItemLayout {
-            margin: padding,
-            ..Default::default()
-        });
+        let paper_props = props
+            .clone()
+            .with(PaperProps {
+                variant: paper_variant,
+                ..Default::default()
+            })
+            .with(paper_theme);
+        let text_props = props
+            .clone()
+            .with(TextPaperProps {
+                text,
+                width,
+                height,
+                variant,
+                use_main_color,
+                alignment_override,
+                transform,
+            })
+            .with(ContentBoxItemLayout {
+                margin: padding,
+                ..Default::default()
+            });
         let alpha = if focused { 1.0 } else { inactive_alpha };
 
         widget! {
@@ -118,14 +129,14 @@ widget_component! {
             ])
         }
     }
-}
+);
 
-widget_component! {
-    pub text_field_paper(key, props) {
+widget_component!(
+    pub fn text_field_paper(key: Key, props: Props) {
         widget! {
             (#{key} input_field: {props.clone()} {
                 content = (#{"content"} text_field_paper_content: {props.clone()})
             })
         }
     }
-}
+);

--- a/raui-material/src/component/switch_paper.rs
+++ b/raui-material/src/component/switch_paper.rs
@@ -13,9 +13,13 @@ pub struct SwitchPaperProps {
 }
 implement_props_data!(SwitchPaperProps);
 
-widget_component! {
-    pub switch_paper(key, props, shared_props) {
-        let SwitchPaperProps { on, variant, size_level } = props.read_cloned_or_default();
+widget_component!(
+    pub fn switch_paper(key: Key, props: Props, shared_props: SharedProps) {
+        let SwitchPaperProps {
+            on,
+            variant,
+            size_level,
+        } = props.read_cloned_or_default();
         let themed_props = props.read_cloned_or_default::<ThemedWidgetProps>();
         let color = match shared_props.read::<ThemeProps>() {
             Ok(props) => match themed_props.color {
@@ -27,7 +31,11 @@ widget_component! {
         };
         let (size, material) = match shared_props.read::<ThemeProps>() {
             Ok(props) => {
-                let size = props.icons_level_sizes.get(size_level).copied().unwrap_or(24.0);
+                let size = props
+                    .icons_level_sizes
+                    .get(size_level)
+                    .copied()
+                    .unwrap_or(24.0);
                 let material = if let Some(material) = props.switch_variants.get(&variant) {
                     if on {
                         material.on.clone()
@@ -63,7 +71,7 @@ widget_component! {
                     height: ImageBoxSizeValue::Exact(size),
                     ..Default::default()
                 }
-            },
+            }
             ThemedImageMaterial::Procedural(data) => ImageBoxProps {
                 material: ImageBoxMaterial::Procedural(data),
                 width: ImageBoxSizeValue::Exact(size),
@@ -75,4 +83,4 @@ widget_component! {
             (#{key} image_box: {image})
         }
     }
-}
+);

--- a/raui-material/src/component/text_paper.rs
+++ b/raui-material/src/component/text_paper.rs
@@ -22,8 +22,8 @@ pub struct TextPaperProps {
 }
 implement_props_data!(TextPaperProps);
 
-widget_component! {
-    pub text_paper(key, props, shared_props) {
+widget_component!(
+    pub fn text_paper(key: Key, props: Props, shared_props: SharedProps) {
         let TextPaperProps {
             text,
             width,
@@ -50,19 +50,21 @@ widget_component! {
             alignment = alignment_override;
         }
         let color = match shared_props.read::<ThemeProps>() {
-            Ok(props) => if use_main_color {
-                match themed_props.color {
-                    ThemeColor::Default => props.active_colors.main.default.main,
-                    ThemeColor::Primary => props.active_colors.main.primary.main,
-                    ThemeColor::Secondary => props.active_colors.main.secondary.main,
+            Ok(props) => {
+                if use_main_color {
+                    match themed_props.color {
+                        ThemeColor::Default => props.active_colors.main.default.main,
+                        ThemeColor::Primary => props.active_colors.main.primary.main,
+                        ThemeColor::Secondary => props.active_colors.main.secondary.main,
+                    }
+                } else {
+                    match themed_props.color {
+                        ThemeColor::Default => props.active_colors.contrast.default.main,
+                        ThemeColor::Primary => props.active_colors.contrast.primary.main,
+                        ThemeColor::Secondary => props.active_colors.contrast.secondary.main,
+                    }
                 }
-            } else {
-                match themed_props.color {
-                    ThemeColor::Default => props.active_colors.contrast.default.main,
-                    ThemeColor::Primary => props.active_colors.contrast.primary.main,
-                    ThemeColor::Secondary => props.active_colors.contrast.secondary.main,
-                }
-            },
+            }
             Err(_) => Default::default(),
         };
         let props = TextBoxProps {
@@ -80,4 +82,4 @@ widget_component! {
             (#{key} text_box: {props})
         }
     }
-}
+);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -127,9 +127,7 @@ fn test_hello_world() {
     // convenient macro that produces widget component processing function.
     widget_component! {
         // <component name> ( [list of context data to unpack into scope] )
-        app(props, named_slots) {
-            // easy way to get widgets from named slots.
-            unpack_named_slots!(named_slots => { title, content });
+        fn app(props: Props, (title, content): NamedSlots) {
             let index = props.read::<AppProps>().map(|p| p.index).unwrap_or(0);
 
             // we always return new widgets tree.
@@ -214,34 +212,37 @@ fn test_hello_world() {
         }
     }
 
-    widget_component! {
-        button(key, props) [use_button] {
+    widget_component!(
+        #[pre(use_button)]
+        fn button(key: Key, props: Props) {
             println!("* PROCESS BUTTON: {}", key);
 
-            widget!{
+            widget! {
                 (#{key} text: {props.clone()})
             }
         }
-    }
+    );
 
-    widget_component! {
-        title_bar(key, props) {
+    widget_component!(
+        fn title_bar(key: Key, props: Props) {
             let title = props.read_cloned_or_default::<String>();
 
             widget! {
                 (#{key} text: {title})
             }
         }
-    }
+    );
 
-    widget_component! {
-        vertical_box(id, key, listed_slots) {
+    widget_component!(
+        fn vertical_box(id: Id, key: Key, listed_slots: ListedSlots) {
             // listed slots are just widget node children.
             // here we just unwrap widget units (final atomic UI elements that renderers read).
             let items = listed_slots
                 .into_iter()
                 .map(|slot| FlexBoxItemNode {
-                    slot: slot.try_into().expect("Cannot convert slot to WidgetUnitNode!"),
+                    slot: slot
+                        .try_into()
+                        .expect("Cannot convert slot to WidgetUnitNode!"),
                     ..Default::default()
                 })
                 .collect::<Vec<_>>();
@@ -255,13 +256,13 @@ fn test_hello_world() {
                 }
             }}}
         }
-    }
+    );
 
-    widget_component! {
-        text(id, key, props) {
+    widget_component!(
+        fn text(id: Id, key: Key, props: Props) {
             let text = props.read_cloned_or_default::<String>();
 
-            widget!{{{
+            widget! {{{
                 TextBoxNode {
                     id: id.to_owned(),
                     text,
@@ -269,7 +270,7 @@ fn test_hello_world() {
                 }
             }}}
         }
-    }
+    );
 
     let mapping = CoordsMapping::new(Rect {
         left: 0.0,
@@ -605,12 +606,13 @@ fn test_refs() {
         }
     }
 
-    widget_component! {
-        test(key) [use_test] {
+    widget_component!(
+        #[pre(use_test)]
+        fn test(key: Key) {
             println!("Render test: {:?}", key);
-            widget!{()}
+            widget! {()}
         }
-    }
+    );
 
     widget_hook! {
         use_app(life_cycle) {
@@ -635,8 +637,9 @@ fn test_refs() {
         }
     }
 
-    widget_component! {
-        app(key, state) [use_app] {
+    widget_component!(
+        #[pre(use_app)]
+        fn app(key: Key, state: State) {
             println!("Render app: {:?}", key);
             let state = state.read_cloned_or_default::<AppState>();
 
@@ -644,7 +647,7 @@ fn test_refs() {
                 (#{key} | {state.test_ref} test)
             }
         }
-    }
+    );
 
     let mut appid = WidgetId::default();
     let mut application = Application::new();
@@ -724,8 +727,9 @@ fn test_scroll_box() {
         }
     }
 
-    widget_component! {
-        app(id, key) [use_nav_container, use_app] {
+    widget_component!(
+        #[pre(use_nav_container, use_app)]
+        fn app(id: Id, key: Key) {
             let scroll_props = Props::new(NavContainerActive)
                 .with(NavItemActive)
                 .with(ScrollViewNotifyProps(id.to_owned().into()))
@@ -745,7 +749,7 @@ fn test_scroll_box() {
                 })
             }
         }
-    }
+    );
 
     let mut button = WidgetId::default();
     let mut application = Application::new();


### PR DESCRIPTION
This is rather presumptuous for a PR that has had no previous discussion, but I wanted to make sure it worked before I submitted the issue so I figured I'd just do a PR once I got it working. 🙂

This PR modifies the input syntax for the `widget_component!` to take valid Rust function syntax. The biggest value of this change is that it makes the component definition syntax compatible with Rustfmt. Now you can format your widget component definitions with `cargo fmt`! I use Rustfmt _heavily_ so this is a big bonus for me.

Here's an example of the new syntax:

```rust
widget_component!(
    // Pre and post hooks are specified with annotations
    #[pre(use_nav_container_active, use_nav_jump_direction_active, use_nav_item)]
    #[post(some_post_action)]
    pub fn component(
        // Argument types are used to control what widget context field to retrieve.
        // The types are not real rust types: they are just used as flags for the macro.
        key: Key,
        // Arguments can be named whatever you want
        my_widget_id: Id,

        // Named slots can be destructured right inside of the argument instead of requring
        // a separate macro call.
        (title, content): NamedSlots,

        items: ListedSlots,
        props: Props,
        shared_props: SharedProps,
        state: State,
        animator: Animator,
    ) {
        // Component logic...

        // Widget output
        widget! {
            (text_box)
        }
    }
);
```

I know you didn't ask for this or anything and I see that nobody else has even contributed to this project yet so I don't know what the climate is for contributions, but I'm open to discussion anything in this PR and if I end up using raui you _might_ be getting more help from me if you're open to it.

If you think this is a good idea I can easily update `widget_hook!` as well.