### PR TITLE
Add Alignment and Direction to BatchExternalText

### DIFF
--- a/raui-tesselate-renderer/src/renderer.rs
+++ b/raui-tesselate-renderer/src/renderer.rs
@@ -63,6 +63,8 @@ impl TextTesselationEngine for () {
                 text: text.text.to_owned(),
                 font: text.font.name.to_owned(),
                 size: text.font.size,
+                alignment: text.alignment,
+                direction: text.direction,
                 color: raui_to_color(text.color),
                 box_size: (layout.local_space.width(), layout.local_space.height()),
                 matrix,

--- a/raui-tesselate-renderer/src/tesselation.rs
+++ b/raui-tesselate-renderer/src/tesselation.rs
@@ -1,5 +1,11 @@
 use crate::Index;
-use raui_core::{widget::WidgetId, Scalar};
+use raui_core::{
+    widget::{
+        unit::text::{TextBoxAlignment, TextBoxDirection},
+        WidgetId,
+    },
+    Scalar,
+};
 use serde::{Deserialize, Serialize};
 use std::ops::Range;
 use vek::Vec2;
@@ -35,6 +41,8 @@ pub struct BatchExternalText {
     pub size: Scalar,
     pub color: Color,
     pub box_size: (Scalar, Scalar),
+    pub alignment: TextBoxAlignment,
+    pub direction: TextBoxDirection,
     pub matrix: [Scalar; 16],
 }
 


### PR DESCRIPTION
This allows external text renderers to properly align text.

I'm using the `BatchExternalText` to handle rendering text, but I needed to know the alignment. 