### PR TITLE
Make Sure Docs.rs Builds With "all" Feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,3 +104,6 @@ members = [
   "demos/todo-app",
   "demos/in-game",
 ]
+
+[package.metadata.docs.rs]
+features = ["all"]


### PR DESCRIPTION
This will include `raui_material` and friends in the docs.rs for `raui` which will make it easier to search for things across the crates.